### PR TITLE
Fixed ULX fancy log admin error.

### DIFF
--- a/lua/ulx/modules/sh/levels.lua
+++ b/lua/ulx/modules/sh/levels.lua
@@ -3,7 +3,7 @@ function ulx.addXP(calling_ply, target_ply, amount)
 	if target_ply.DarkRPUnInitialized then return end
 	target_ply:addXP(amount, true)
 	DarkRP.notify(target_ply, 0,4,calling_ply:Nick() .. " gave you "..amount.."XP")
-	ulx.fancyLogAdmin(calling_ply:Nick() .. " gave "..target_ply:Nick().." "..amount)
+	ulx.fancyLogAdmin(calling_ply, "#A has gave #T an xp amount of #s", target_ply, amount)
 end
 local addXPx = ulx.command("Levels", "ulx addxp", ulx.addXP, "!addxp")
 addXPx:addParam{type=ULib.cmds.PlayerArg}
@@ -18,7 +18,7 @@ function ulx.setLevel(calling_ply, target_ply, level)
         target_ply:setDarkRPVar("level",level)
         target_ply:setDarkRPVar("xp",0)
 	DarkRP.notify(target_ply, 0,4,calling_ply:Nick() .. " set your level to "..level)
-	ulx.fancyLogAdmin(calling_ply:Nick() .. " set "..target_ply:Nick().." level to "..level)
+	ulx.fancyLogAdmin(calling_ply, "#A has set #T level to #s", target_ply, level)
 end
 local setLevelx = ulx.command("Levels", "ulx setlevel", ulx.setLevel, "!setlevel")
 setLevelx:addParam{type=ULib.cmds.PlayerArg}


### PR DESCRIPTION
Before the changes, if a player set someone's level or added XP through ULX. It would not print the fancy log admin message and would throw a serverside error.