### PR TITLE
Level display showing for LocalPlayer and when a player is cloaked FIX

### DIFF
--- a/lua/darkrp_modules/levels/cl_hud.lua
+++ b/lua/darkrp_modules/levels/cl_hud.lua
@@ -35,6 +35,8 @@ local shouldDraw, players = hook.Call("HUDShouldDraw", GAMEMODE, "DarkRP_EntityD
 	if(LevelSystemConfiguration.DisplayLevel) then
 		for k, ply in pairs(players or player.GetAll()) do
 			if not ply:Alive() then continue end
+			if ply:GetRenderMode() == RENDERMODE_TRANSALPHA then continue end // player is cloaked (ULX)
+			if ply == LocalPlayer() then continue end
 			local hisPos = ply:GetShootPos()
 			if GAMEMODE.Config.globalshow and ply ~= localplayer then
 					local pos = ply:EyePos()


### PR DESCRIPTION
Level does not show when player is cloaked (ULX support)

Also player cannot see their own level above head, for example if they are in third person it will not render.